### PR TITLE
ci: Pin OS versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,25 +4,34 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
     name: OTP ${{matrix.otp}} / Elixir ${{matrix.elixir}}
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
+        # Compatibility info can be found at
+        # https://github.com/erlef/setup-beam?tab=readme-ov-file#compatibility-between-operating-system-and-erlangotp
         include:
           - elixir: "1.7.4"
             otp: "22"
+            os: ubuntu-20.04
           - elixir: "1.8.1"
             otp: "22"
+            os: ubuntu-20.04
           - elixir: "1.9.4"
             otp: "22"
+            os: ubuntu-20.04
           - elixir: "1.10.4"
             otp: "23"
+            os: ubuntu-20.04
           - elixir: "1.11.4"
             otp: "24"
+            os: ubuntu-24.04
           - elixir: "1.12.3"
             otp: "24"
+            os: ubuntu-24.04
           - elixir: "1.13.4"
             otp: "24"
+            os: ubuntu-24.04
     env:
       MIX_ENV: test
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,18 +11,6 @@ jobs:
         # Compatibility info can be found at
         # https://github.com/erlef/setup-beam?tab=readme-ov-file#compatibility-between-operating-system-and-erlangotp
         include:
-          - elixir: "1.7.4"
-            otp: "22"
-            os: ubuntu-20.04
-          - elixir: "1.8.1"
-            otp: "22"
-            os: ubuntu-20.04
-          - elixir: "1.9.4"
-            otp: "22"
-            os: ubuntu-20.04
-          - elixir: "1.10.4"
-            otp: "23"
-            os: ubuntu-20.04
           - elixir: "1.11.4"
             otp: "24"
             os: ubuntu-24.04


### PR DESCRIPTION
erlef/setup-beam supports [several specific versions](https://github.com/erlef/setup-beam?tab=readme-ov-file#compatibility-between-operating-system-and-erlangotp) of OTP and Elixir for each OS versions of GitHub Actions runners. 

This commit pins OS versions for CI to resolve ["version not found" errors](https://github.com/mtannaan/elixpath/pull/10/checks).

This commit also excludes Elixir < 1.11 from CI checks, as these Elixir versions require GitHub actions runners with Ubuntu 20.04, which version has been [deprecated](https://github.com/actions/runner-images/issues/11101).