### PR TITLE
ci: add CI for Elixir 1.12 to 1.18

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,8 @@
 on:
-- push
-- pull_request
+  pull_request:
+  push:
+    branches:
+      - master
 
 jobs:
   test:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,22 @@ jobs:
             otp: "24"
             os: ubuntu-24.04
           - elixir: "1.13.4"
-            otp: "24"
+            otp: "25"
+            os: ubuntu-24.04
+          - elixir: "1.14.5"
+            otp: "26"
+            os: ubuntu-24.04
+          - elixir: "1.15.8"
+            otp: "26"
+            os: ubuntu-24.04
+          - elixir: "1.16.3"
+            otp: "26"
+            os: ubuntu-24.04
+          - elixir: "1.17.3"
+            otp: "27"
+            os: ubuntu-24.04
+          - elixir: "1.18.3"
+            otp: "27"
             os: ubuntu-24.04
     env:
       MIX_ENV: test

--- a/mix.exs
+++ b/mix.exs
@@ -33,7 +33,11 @@ defmodule Elixpath.MixProject do
       # {:dep_from_git, git: "https://github.com/elixir-lang/my_dep.git", tag: "0.1.0"},
       {:nimble_parsec, "~> 0.5 or ~>1.0", runtime: false},
       {:ex_doc, "~>0.28", only: [:dev], runtime: false},
-      {:excoveralls, "~> 0.14.6", only: [:test]}
+      {:excoveralls, "~> 0.14.6", only: [:test]},
+      # ---
+      # dependency :ssl_verify needs this for compilation
+      # https://github.com/edgurgel/httpoison/issues/46
+      {:ssl_verify_fun, ">= 0.0.0", manager: :rebar3, override: true}
     ]
   end
 


### PR DESCRIPTION
- add CI for Elixir 1.12 to 1.18
- update mix.exs to use latest `:ssl_verify` to workaround compilation failure during CI