### PR TITLE
ci: disable fail_ci_if_error of codecov-action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,5 +51,5 @@ jobs:
       - uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          fail_ci_if_error: true
+          fail_ci_if_error: false
           name: OTP ${{matrix.otp}} / Elixir ${{matrix.elixir}}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
       - run: mix deps.get
       - run: mix compile
       - run: mix coveralls.json
-      - uses: codecov/codecov-action@v3
+      - uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true


### PR DESCRIPTION
- disable fail_ci_if_error of codecov-action, as the action may fail in forked repos
- bump codecov-action to v5, hoping to support [uploading without token](https://docs.codecov.com/docs/codecov-tokens#uploading-without-a-token) to Codecov