### PR TITLE
Fix publish error in release v0.1.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,10 @@ jobs:
         with:
           otp-version: ${{matrix.otp}}
           elixir-version: ${{matrix.elixir}}
+      # Workaround compilation error
+      # https://github.com/mtannaan/elixpath/actions/runs/15115152687/job/42483859402?pr=17
+      # https://gist.github.com/Dowwie/6186049eefbf606a307d467e5537b2ed
+      - run: mix deps.unlock ssl_verify_fun
       - run: mix deps.get
       - run: mix compile
       - run: mix coveralls.json

--- a/mix.exs
+++ b/mix.exs
@@ -33,11 +33,7 @@ defmodule Elixpath.MixProject do
       # {:dep_from_git, git: "https://github.com/elixir-lang/my_dep.git", tag: "0.1.0"},
       {:nimble_parsec, "~> 0.5 or ~>1.0", runtime: false},
       {:ex_doc, "~>0.28", only: [:dev], runtime: false},
-      {:excoveralls, "~> 0.14.6", only: [:test]},
-      # ---
-      # dependency :ssl_verify needs this for compilation
-      # https://github.com/edgurgel/httpoison/issues/46
-      {:ssl_verify_fun, ">= 0.0.0", manager: :rebar3, override: true}
+      {:excoveralls, "~> 0.14.6", only: [:test]}
     ]
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Elixpath.MixProject do
   def project do
     [
       app: :elixpath,
-      version: "0.1.1",
+      version: "0.1.2",
       elixir: ">= 1.7.0",
       start_permanent: Mix.env() == :prod,
       description: description(),


### PR DESCRIPTION
mix hex.publish after merging #15 [failed](https://github.com/mtannaan/elixpath/actions/runs/14976210167/job/42069100719) because of `override: true` in dependency ssl_verify_fun. The `override` was introduced in #12 to workaround compilation failure during CI.

In this PR the workaround is reverted, and `mix deps.unlock ssl_verify_fun` is added to CI instead.